### PR TITLE
Adapt plugin to GitBook 3

### DIFF
--- a/assets/plugin.js
+++ b/assets/plugin.js
@@ -1,0 +1,7 @@
+require([
+    'gitbook'
+], function(gitbook) {
+    gitbook.events.on('start', function(e, config) {
+        $('.fancybox').fancybox(config.fancybox);
+    });
+});

--- a/index.js
+++ b/index.js
@@ -27,17 +27,18 @@ module.exports = {
   },
   hooks: {
     page: function(page) {
-      _.each(page.sections, function(section) {
-        var $ = cheerio.load(section.content);
-        $('img').each(function(index, img) {
-          var $img = $(img);
-          $img.replaceWith(template({
-            url: $img.attr('src'),
-            title: $img.attr('alt')
-          }));
-        });
-        section.content = $.html();
+      var $ = cheerio.load(page.content);
+
+      $('img').each(function(index, img) {
+        var $img = $(img);
+        $img.replaceWith(template({
+          url: $img.attr('src'),
+          title: $img.attr('alt')
+        }));
       });
+
+      page.content = $.html();
+
       return page;
     }
   }

--- a/index.js
+++ b/index.js
@@ -3,12 +3,6 @@ var cheerio = require('cheerio');
 var _ = require('underscore');
 var multiline = require('multiline');
 
-var defaultConfig = {
-  helpers: {
-    buttons: {}
-  }
-};
-
 var template = _.template(multiline(function() {
   /*
      <a href="<%= url %>" title="<%= title %>" class="fancybox">

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var multiline = require('multiline');
 
 var template = _.template(multiline(function() {
   /*
-     <a href="<%= url %>" title="<%= title %>" class="fancybox">
+     <a href="<%= url %>" title="<%= title %>" target="_self" class="fancybox">
        <img src="<%= url %>" alt="<%= title %>"></img>
      </a>
    */

--- a/index.js
+++ b/index.js
@@ -23,20 +23,13 @@ module.exports = {
     js: [
       'jquery.min.js',
       'jquery.fancybox.pack.js',
-      'jquery.fancybox-buttons.js'
+      'jquery.fancybox-buttons.js',
+      'plugin.js'
     ],
     css: [
       'jquery.fancybox.css',
       'jquery.fancybox-buttons.css'
-    ],
-    html: {
-      'body:end': function() {
-        var config = _.defaults(this.options.pluginsConfig.fancybox,
-          defaultConfig);
-        return '<script>$(".fancybox").fancybox(JSON.parse(\'' + JSON.stringify(
-          config) + '\'));</script>';
-      }
-    }
+    ]
   },
   hooks: {
     page: function(page) {

--- a/package.json
+++ b/package.json
@@ -31,5 +31,15 @@
   "bugs": {
     "url": "https://github.com/LingyuCoder/gitbook-plugin-fancybox/issues"
   },
-  "homepage": "https://github.com/LingyuCoder/gitbook-plugin-fancybox"
+  "homepage": "https://github.com/LingyuCoder/gitbook-plugin-fancybox",
+  "gitbook": {
+    "properties": {
+      "helpers": {
+        "type": "object",
+        "default": {
+          "buttons": {}
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
Hello,

We will soon release [GitBook v3](https://github.com/GitbookIO/gitbook).
The plugins API has been updated, as you will see [in the GitBook 3 documentation](http://toolchain.gitbook.com/).

I'm in charge of reviewing the existing plugins for maintaining the compatibility with this new version.
In this version, the hooks used for this plugin will not be supported, since we are relying a lot more on the templating system to extend the books HTML.

The proposed PR has been tested with the new version.
It includes the script using native `gitbook.events` in the `assets/plugin.js` file.
I also moved default configuration to `package.json` and used the new API `page.content` instead of the deprecated `page.sections` from GitBook 2.

Let me know if you have any remarks regarding what is done, and don't forget to publish a new version if you merge it :)
You will have to specify the engine in your new version's `package.json`:

``` JSON
"engines": {
    "gitbook": ">=3.0.0-pre.0"
}
```

Kind regards,
Johan
